### PR TITLE
adding support for claude, cohere, llama2, azure

### DIFF
--- a/llmflows/llms/llm_utils.py
+++ b/llmflows/llms/llm_utils.py
@@ -47,7 +47,10 @@ def call_with_retry(api_obj, max_retries, *args, **kwargs):
 
     while num_retries <= max_retries:
         try:
-            response = api_obj.create(*args, **kwargs)
+            if "completion" == str(api_obj.__name__):
+                response = api_obj(*args, **kwargs)
+            else: 
+                response = api_obj.create(*args, **kwargs)
             return response, num_retries
 
         except (
@@ -101,7 +104,10 @@ async def async_call_with_retry(api_obj, max_retries, *args, **kwargs):
 
     while num_retries <= max_retries:
         try:
-            response = await api_obj.acreate(*args, **kwargs)
+            if "completion" == str(api_obj.__name__):
+                response = await api_obj(*args, **kwargs)
+            else: 
+                response = await api_obj.acreate(*args, **kwargs)
             return response, num_retries
 
         except (

--- a/llmflows/llms/openai_chat.py
+++ b/llmflows/llms/openai_chat.py
@@ -5,6 +5,8 @@ base class.
 """
 
 import openai
+import litellm 
+from litellm import completion, acompletion
 from llmflows.llms.llm import BaseLLM
 from llmflows.llms.llm_utils import call_with_retry, async_call_with_retry
 from llmflows.llms.message_history import MessageHistory
@@ -99,7 +101,7 @@ class OpenAIChat(BaseLLM):
         """
 
         completion, retries = call_with_retry(
-            api_obj=openai.ChatCompletion,
+            api_obj=completion,
             max_retries=self.max_retries,
             model=self.model,
             messages=message_history.messages,
@@ -126,7 +128,7 @@ class OpenAIChat(BaseLLM):
         """
 
         completion, retries = await async_call_with_retry(
-            api_obj=openai.ChatCompletion,
+            api_obj=acompletion,
             max_retries=self.max_retries,
             model=self.model,
             messages=message_history.messages,


### PR DESCRIPTION
Hey @stoyan-stoyanov ,

Noticed you're only calling OpenAI. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

Added support for Claude, Cohere, Azure and Llama2 (via Replicate) by replacing the ChatOpenAI `completion` call with a litellm `completion` call. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.